### PR TITLE
bug fix for parsing attribute!=null correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ export class MongooseQueryParser {
           result[key][op] = prefix !== '!';
         } else if (op === '$eq') {
           result[key] = value;
-        } else if (op === '$ne' && typeof value === 'object') {
+        } else if (op === '$ne' && typeof value === 'object' && value!== null) {
           result[key].$not = value;
         } else {
           result[key][op] = value;


### PR DESCRIPTION
parses URL query string, key!=null correctly to key: {$ne: null} instead of key: {$not: null} which resulted in Mongo error.